### PR TITLE
Fixed ALTER TYPE to update column types

### DIFF
--- a/internal/sql/catalog/types.go
+++ b/internal/sql/catalog/types.go
@@ -207,5 +207,16 @@ func (c *Catalog) renameType(stmt *ast.RenameTypeStmt) error {
 
 	}
 
+	// Update all the table column with the new type
+	for si, schema := range c.Schemas {
+		for ti, table := range schema.Tables {
+			for ci, column := range table.Columns {
+				if column.Type == *stmt.Type {
+					c.Schemas[si].Tables[ti].Columns[ci].Type.Name = newName
+				}
+			}
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Fixed issue when ALTER TYPE does not update all the columns that uses that type.  Example below does not work correctly, but does with this fix.

```
CREATE TYPE event AS enum ('START', 'STOP');

CREATE TABLE log_lines (
  id     BIGSERIAL    PRIMARY KEY,
  status "event"  NOT NULL
);

ALTER TYPE event RENAME TO "new_event";

-- name: ListAuthors :many
SELECT * FROM log_lines;

```